### PR TITLE
Added 'InternalProcessing' object to base xarf

### DIFF
--- a/samples/negative/development/invalid_internal_processing_wrong_data_type.json
+++ b/samples/negative/development/invalid_internal_processing_wrong_data_type.json
@@ -1,0 +1,45 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterOrg": "ExampleOrg",
+    "ReporterOrgDomain": "example.com",
+    "ReporterOrgEmail": "reports@example.com",
+    "ReporterContactEmail": "contact@example.com",
+    "ReporterContactName": "Mr. Example",
+    "ReporterContactPhone": "+ 01 000 1234567"
+  },
+  "Disclosure": true,
+  "InternalProcessing":
+  {
+    "SubscriberInformation": {
+      "ID": 123112,
+      "SubscriberData": {
+        "Active": true
+      }
+    },
+    "EventTags": ["Wordpress", 9, "Untrusted"]
+  },
+  "Report": {
+    "ReportType": "OpenService",
+    "ReportClass": "Vulnerability",
+    "FirstSeen": "2020-03-15T15:17:10Z",
+    "Date": "2020-07-24T14:17:10Z",
+    "ServiceName": "redis",
+    "ServiceVersion": "1.2.4",
+    "SourceIp": "192.0.2.55",
+    "SourcePort": 54321,
+    "TransportProtocol": "tcp",
+    "Samples": [
+      {
+        "ContentType": "text/plain",
+        "Base64Encoded": false,
+        "Description": "Log line",
+        "Payload": "EXAMPLE Nmap done: 1 IP address (1 host up) scanned in 5.58 seconds EXAMPLE"
+      }
+    ],
+    "Custom": {
+      "whatever": "examplevalue",
+      "whatever2": "examplevalue2"
+    }
+  }
+}

--- a/samples/negative/development/invalid_internal_processing_wrong_data_type.json
+++ b/samples/negative/development/invalid_internal_processing_wrong_data_type.json
@@ -9,8 +9,7 @@
     "ReporterContactPhone": "+ 01 000 1234567"
   },
   "Disclosure": true,
-  "InternalProcessing":
-  {
+  "InternalProcessing": {
     "SubscriberInformation": {
       "ID": 123112,
       "SubscriberData": {

--- a/samples/positive/development/loginattack_sample_optional_api_info.json
+++ b/samples/positive/development/loginattack_sample_optional_api_info.json
@@ -1,0 +1,49 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterOrg": "ExampleOrg",
+    "ReporterOrgDomain": "example.com",
+    "ReporterOrgEmail": "reports@example.com",
+    "ReporterContactEmail": "contact@example.com",
+    "ReporterContactName": "Mr. Example",
+    "ReporterContactPhone": "+ 01 000 1234567"
+  },
+  "Disclosure": true,
+  "InternalProcessing":
+  {
+    "SubscriberInformation": {
+      "ID": "32.112.219.3",
+      "SubscriberData": {
+        "PreviousStrikes": "3",
+        "LastStrike": "2018-02-01T07:32:00Z"
+      }
+    },
+    "ContractInformation": {
+      "ID": "32.112.219.3-premium",
+      "ResolverData": {
+        "ExpirationDate": "2019-01-01T00:00:00Z"
+      }
+    },
+    "EventTags": ["SSH", "Untrusted", "BruteForce"]
+  },
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "LoginAttack",
+    "Date": "2018-02-05T14:17:10Z",
+    "SourceIp": "192.0.2.55",
+    "SourcePort": 54321,
+    "DestinationIp": "198.51.100.33",
+    "DestinationPort": 80,
+    "Ongoing": true,
+    "ByteCount": 20000000,
+    "PacketCount": 10000,
+    "Samples": [
+      {
+        "ContentType": "text/plain",
+        "Base64Encoded": false,
+        "Description": "Log entry",
+        "Payload": "User at 192.0.2.55:54321 tried to log in unsuccessfully 123 times."
+      }
+    ]
+  }
+}

--- a/samples/positive/development/loginattack_sample_optional_api_info.json
+++ b/samples/positive/development/loginattack_sample_optional_api_info.json
@@ -9,8 +9,7 @@
     "ReporterContactPhone": "+ 01 000 1234567"
   },
   "Disclosure": true,
-  "InternalProcessing":
-  {
+  "InternalProcessing": {
     "SubscriberInformation": {
       "ID": "32.112.219.3",
       "SubscriberData": {

--- a/samples/positive/development/openservice_sample_optional_api_info.json
+++ b/samples/positive/development/openservice_sample_optional_api_info.json
@@ -9,8 +9,7 @@
     "ReporterContactPhone": "+ 01 000 1234567"
   },
   "Disclosure": true,
-  "InternalProcessing":
-  {
+  "InternalProcessing": {
     "SubscriberInformation": {
       "ID": "32141@customer.com",
       "SubscriberData": {

--- a/samples/positive/development/openservice_sample_optional_api_info.json
+++ b/samples/positive/development/openservice_sample_optional_api_info.json
@@ -1,0 +1,53 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterOrg": "ExampleOrg",
+    "ReporterOrgDomain": "example.com",
+    "ReporterOrgEmail": "reports@example.com",
+    "ReporterContactEmail": "contact@example.com",
+    "ReporterContactName": "Mr. Example",
+    "ReporterContactPhone": "+ 01 000 1234567"
+  },
+  "Disclosure": true,
+  "InternalProcessing":
+  {
+    "SubscriberInformation": {
+      "ID": "32141@customer.com",
+      "SubscriberData": {
+        "CustomerEMail": "contact@customer.com",
+        "CustomerGeo": "South America",
+        "AccountContact": "Mr. Contact Person"
+      }
+    },
+    "ContractInformation": {
+      "ID": "32141@customer.com-service",
+      "ResolverData": {
+        "Active": "true"
+      }
+    },
+    "EventTags": ["Wordpress", "Admin", "Untrusted"]
+  },
+  "Report": {
+    "ReportType": "OpenService",
+    "ReportClass": "Vulnerability",
+    "FirstSeen": "2020-03-15T15:17:10Z",
+    "Date": "2020-07-24T14:17:10Z",
+    "ServiceName": "redis",
+    "ServiceVersion": "1.2.4",
+    "SourceIp": "192.0.2.55",
+    "SourcePort": 54321,
+    "TransportProtocol": "tcp",
+    "Samples": [
+      {
+        "ContentType": "text/plain",
+        "Base64Encoded": false,
+        "Description": "Log line",
+        "Payload": "EXAMPLE Nmap done: 1 IP address (1 host up) scanned in 5.58 seconds EXAMPLE"
+      }
+    ],
+    "Custom": {
+      "whatever": "examplevalue",
+      "whatever2": "examplevalue2"
+    }
+  }
+}

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -41,11 +41,7 @@
           "minLength": 3
         }
       },
-      "required": [
-        "ReporterOrg",
-        "ReporterOrgDomain",
-        "ReporterOrgEmail"
-      ]
+      "required": ["ReporterOrg", "ReporterOrgDomain", "ReporterOrgEmail"]
     },
     "OnBehalfOf": {
       "type": "object",
@@ -109,11 +105,7 @@
           "$ref": "#/properties/InternalProcessing"
         }
       },
-      "required": [
-        "ReporterInfo",
-        "Disclosure",
-        "Version"
-      ]
+      "required": ["ReporterInfo", "Disclosure", "Version"]
     },
     "ReportBase": {
       "description": "Base properties for the report part of all xarf report types",
@@ -122,11 +114,7 @@
         "ReportClass": {
           "type": "string",
           "description": "class of the reported abuse event",
-          "enum": [
-            "Content",
-            "Activity",
-            "Vulnerability"
-          ]
+          "enum": ["Content", "Activity", "Vulnerability"]
         },
         "ReportType": {
           "type": "string",
@@ -144,11 +132,7 @@
         "ReporterSeverity": {
           "type": "string",
           "description": "class of the reported abuse event",
-          "enum": [
-            "low",
-            "medium",
-            "high"
-          ]
+          "enum": ["low", "medium", "high"]
         },
         "ReporterNotes": {
           "type": "string",
@@ -169,10 +153,7 @@
           }
         }
       },
-      "required": [
-        "ReportClass",
-        "ReportType"
-      ]
+      "required": ["ReportClass", "ReportType"]
     },
     "IpBasedReport": {
       "allOf": [
@@ -211,9 +192,7 @@
               "maximum": 4199999999
             }
           },
-          "required": [
-            "SourceIp"
-          ]
+          "required": ["SourceIp"]
         }
       ]
     },
@@ -240,9 +219,7 @@
           "anyOf": [
             {
               "type": "object",
-              "required": [
-                "SourceIp"
-              ],
+              "required": ["SourceIp"],
               "properties": {
                 "SourceIp": {
                   "description": "ip from that the abuse event originated",
@@ -267,9 +244,7 @@
             },
             {
               "type": "object",
-              "required": [
-                "SourceUrl"
-              ],
+              "required": ["SourceUrl"],
               "properties": {
                 "SourceUrl": {
                   "type": "string",
@@ -306,10 +281,7 @@
               "description": "actual sample"
             }
           },
-          "required": [
-            "ContentType",
-            "Payload"
-          ]
+          "required": ["ContentType", "Payload"]
         },
         {
           "$ref": "#/properties/File"
@@ -341,9 +313,7 @@
     "Date": {
       "description": "stores either a single date or two dates, one for the first occurrence of the event, one for the most recent",
       "type": "object",
-      "required": [
-        "Date"
-      ],
+      "required": ["Date"],
       "properties": {
         "Date": {
           "format": "date-time",
@@ -375,9 +345,7 @@
           "description": "hash value of the file"
         }
       },
-      "required": [
-        "FileName"
-      ]
+      "required": ["FileName"]
     },
     "WithDestination": {
       "type": "object",
@@ -471,9 +439,7 @@
     "Service": {
       "type": "object",
       "description": "Specify a service to report",
-      "required": [
-        "ServiceName"
-      ],
+      "required": ["ServiceName"],
       "properties": {
         "ServiceName": {
           "type": "string"
@@ -490,10 +456,7 @@
       "properties": {
         "TransportProtocol": {
           "type": "string",
-          "enum": [
-            "tcp",
-            "udp"
-          ]
+          "enum": ["tcp", "udp"]
         }
       }
     },

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -41,7 +41,11 @@
           "minLength": 3
         }
       },
-      "required": ["ReporterOrg", "ReporterOrgDomain", "ReporterOrgEmail"]
+      "required": [
+        "ReporterOrg",
+        "ReporterOrgDomain",
+        "ReporterOrgEmail"
+      ]
     },
     "OnBehalfOf": {
       "type": "object",
@@ -100,9 +104,16 @@
         },
         "Version": {
           "const": "development"
+        },
+        "InternalProcessing": {
+          "$ref": "#/properties/InternalProcessing"
         }
       },
-      "required": ["ReporterInfo", "Disclosure", "Version"]
+      "required": [
+        "ReporterInfo",
+        "Disclosure",
+        "Version"
+      ]
     },
     "ReportBase": {
       "description": "Base properties for the report part of all xarf report types",
@@ -111,7 +122,11 @@
         "ReportClass": {
           "type": "string",
           "description": "class of the reported abuse event",
-          "enum": ["Content", "Activity", "Vulnerability"]
+          "enum": [
+            "Content",
+            "Activity",
+            "Vulnerability"
+          ]
         },
         "ReportType": {
           "type": "string",
@@ -129,7 +144,11 @@
         "ReporterSeverity": {
           "type": "string",
           "description": "class of the reported abuse event",
-          "enum": ["low", "medium", "high"]
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
         },
         "ReporterNotes": {
           "type": "string",
@@ -139,11 +158,21 @@
           "type": "object",
           "description": "allows for custom key-value fields",
           "additionalProperties": {
-            "anyOf": [{ "type": "string" }, { "type": "integer" }]
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
           }
         }
       },
-      "required": ["ReportClass", "ReportType"]
+      "required": [
+        "ReportClass",
+        "ReportType"
+      ]
     },
     "IpBasedReport": {
       "allOf": [
@@ -182,7 +211,9 @@
               "maximum": 4199999999
             }
           },
-          "required": ["SourceIp"]
+          "required": [
+            "SourceIp"
+          ]
         }
       ]
     },
@@ -209,7 +240,9 @@
           "anyOf": [
             {
               "type": "object",
-              "required": ["SourceIp"],
+              "required": [
+                "SourceIp"
+              ],
               "properties": {
                 "SourceIp": {
                   "description": "ip from that the abuse event originated",
@@ -234,7 +267,9 @@
             },
             {
               "type": "object",
-              "required": ["SourceUrl"],
+              "required": [
+                "SourceUrl"
+              ],
               "properties": {
                 "SourceUrl": {
                   "type": "string",
@@ -271,7 +306,10 @@
               "description": "actual sample"
             }
           },
-          "required": ["ContentType", "Payload"]
+          "required": [
+            "ContentType",
+            "Payload"
+          ]
         },
         {
           "$ref": "#/properties/File"
@@ -303,7 +341,9 @@
     "Date": {
       "description": "stores either a single date or two dates, one for the first occurrence of the event, one for the most recent",
       "type": "object",
-      "required": ["Date"],
+      "required": [
+        "Date"
+      ],
       "properties": {
         "Date": {
           "format": "date-time",
@@ -335,7 +375,9 @@
           "description": "hash value of the file"
         }
       },
-      "required": ["FileName"]
+      "required": [
+        "FileName"
+      ]
     },
     "WithDestination": {
       "type": "object",
@@ -429,7 +471,9 @@
     "Service": {
       "type": "object",
       "description": "Specify a service to report",
-      "required": ["ServiceName"],
+      "required": [
+        "ServiceName"
+      ],
       "properties": {
         "ServiceName": {
           "type": "string"
@@ -446,7 +490,49 @@
       "properties": {
         "TransportProtocol": {
           "type": "string",
-          "enum": ["tcp", "udp"]
+          "enum": [
+            "tcp",
+            "udp"
+          ]
+        }
+      }
+    },
+    "InternalProcessing": {
+      "type": "object",
+      "description": "Information about the reportee for internal processing. This should be ignored if the reporter isn't authorized. It's intended to be used for relaying internaly generated xarf-reports to automation software.",
+      "properties": {
+        "SubscriberInformation": {
+          "ID": {
+            "type": "string",
+            "description": "Internal ID of the reportee."
+          },
+          "SubscriberData": {
+            "type": "object",
+            "description": "Data about a customer normaly returned by a resolver in the process of determining the reportee.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "ContractInformation": {
+          "ID": {
+            "type": "string",
+            "description": "Internal ID of the reportee's contract."
+          },
+          "ResolverData": {
+            "type": "object",
+            "description": "Data about a customers contract normaly returned by a resolver in the process of determining the reportee.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        },
+        "EventTags": {
+          "type": "array",
+          "description": "Custom tags for classification, metrics and other internal uses.",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -502,28 +502,36 @@
       "description": "Information about the reportee for internal processing. This should be ignored if the reporter isn't authorized. It's intended to be used for relaying internaly generated xarf-reports to automation software.",
       "properties": {
         "SubscriberInformation": {
-          "ID": {
-            "type": "string",
-            "description": "Internal ID of the reportee."
-          },
-          "SubscriberData": {
-            "type": "object",
-            "description": "Data about a customer normaly returned by a resolver in the process of determining the reportee.",
-            "additionalProperties": {
-              "type": "string"
+          "type": "object",
+          "description": "Information about the reportee/customer.",
+          "properties": {
+            "ID": {
+              "type": "string",
+              "description": "Internal ID of the reportee."
+            },
+            "SubscriberData": {
+              "type": "object",
+              "description": "Data about a customer normaly returned by a resolver in the process of determining the reportee.",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         },
         "ContractInformation": {
-          "ID": {
-            "type": "string",
-            "description": "Internal ID of the reportee's contract."
-          },
-          "ResolverData": {
-            "type": "object",
-            "description": "Data about a customers contract normaly returned by a resolver in the process of determining the reportee.",
-            "additionalProperties": {
-              "type": "string"
+          "type": "object",
+          "description": "Information about the reportee's/customer's contract.",
+          "properties": {
+            "ID": {
+              "type": "string",
+              "description": "Internal ID of the reportee's contract."
+            },
+            "ResolverData": {
+              "type": "object",
+              "description": "Data about a customers contract normaly returned by a resolver in the process of determining the reportee.",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         },


### PR DESCRIPTION
 ## Intended for workflow automation when using xarf as an internal reporting tool.

Adds 
```json
"SubscriberInformation": {"ID": "string", "SubscriberData": {}}
```
```json
"ContractInformation": {"ID": "string", "ResolverData": {}}
```
```json
"EventTags": []
```

These fields can be used by automation tools, by using xarf reports as an internal resource for relaying and processing self-generated reports, or when using xarf as the internal representation of a report processing tool.