### PR TITLE
Schema proposal: Harassment

### DIFF
--- a/samples/negative/development/harassment_sample_no_description.json
+++ b/samples/negative/development/harassment_sample_no_description.json
@@ -1,0 +1,18 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterType": "Person",
+    "ReporterContactEmail": "contact@example.com",
+    "ReporterContactName": "Harassed McPerson",
+    "ReporterContactPhone": "+ 01 555 1234567"
+  },
+  "Disclosure": true,
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Harassed",
+    "Date": "2022-09-09T14:17:10Z",
+    "SourceUrl": "192.168.0.11",
+    "Ongoing": true,
+    "Harasser": "x.X.Fl4m3r.X.x",
+  }
+}

--- a/samples/negative/development/harassment_sample_no_description.json
+++ b/samples/negative/development/harassment_sample_no_description.json
@@ -13,6 +13,6 @@
     "Date": "2022-09-09T14:17:10Z",
     "SourceUrl": "192.168.0.11",
     "Ongoing": true,
-    "Harasser": "x.X.Fl4m3r.X.x",
+    "Harasser": "x.X.Fl4m3r.X.x"
   }
 }

--- a/samples/negative/development/harassment_sample_no_harasser.json
+++ b/samples/negative/development/harassment_sample_no_harasser.json
@@ -1,0 +1,18 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterType": "Person",
+    "ReporterContactEmail": "contact@example.com",
+    "ReporterContactName": "Harassed McPerson",
+    "ReporterContactPhone": "+ 01 555 1234567"
+  },
+  "Disclosure": true,
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Harassed",
+    "Date": "2022-09-09T14:17:10Z",
+    "SourceUrl": "192.168.0.11",
+    "Ongoing": true,
+    "HarassmentDescription": "The user called me a bunch of slurs."
+  }
+}

--- a/samples/negative/development/invalid_missing_reporter_props4.json
+++ b/samples/negative/development/invalid_missing_reporter_props4.json
@@ -1,0 +1,23 @@
+{
+  "Version": "development",
+  "ReporterInfo": [],
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Spam",
+    "ReportSubType": "Trap",
+    "Date": "2018-02-05T14:17:10Z",
+    "SourceIp": "192.0.2.55",
+    "SourcePort": 54321,
+    "DestinationIp": "198.51.100.33",
+    "DestinationPort": 25,
+    "SmtpMailFromAddress": "spam@domain.com",
+    "Samples": [
+      {
+        "ContentType": "message/rfc822",
+        "Base64Encoded": true,
+        "Description": "The spam mail",
+        "Payload": "bWFpbA=="
+      }
+    ]
+  }
+}

--- a/samples/negative/development/invalid_missing_reporter_props5.json
+++ b/samples/negative/development/invalid_missing_reporter_props5.json
@@ -1,0 +1,26 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterOrg": "ExampleOrg",
+    "ReporterOrgDomain": "example.com"
+  },
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Spam",
+    "ReportSubType": "Trap",
+    "Date": "2018-02-05T14:17:10Z",
+    "SourceIp": "192.0.2.55",
+    "SourcePort": 54321,
+    "DestinationIp": "198.51.100.33",
+    "DestinationPort": 25,
+    "SmtpMailFromAddress": "spam@domain.com",
+    "Samples": [
+      {
+        "ContentType": "message/rfc822",
+        "Base64Encoded": true,
+        "Description": "The spam mail",
+        "Payload": "bWFpbA=="
+      }
+    ]
+  }
+}

--- a/samples/positive/development/harassment_sample_game.json
+++ b/samples/positive/development/harassment_sample_game.json
@@ -9,9 +9,9 @@
   "Disclosure": true,
   "Report": {
     "ReportClass": "Activity",
-    "ReportType": "Harassed",
+    "ReportType": "Harassment",
     "Date": "2022-09-09T14:17:10Z",
-    "SourceUrl": "192.168.0.11",
+    "SourceUrl": "https://thepetgoatgame.play",
     "Ongoing": true,
     "Harasser": "x.X.Fl4m3r.X.x",
     "HarassmentLocation": "game",

--- a/samples/positive/development/harassment_sample_image.json
+++ b/samples/positive/development/harassment_sample_image.json
@@ -1,0 +1,29 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterType": "Person",
+    "ReporterContactEmail": "contact@example.com",
+    "ReporterContactName": "Harassed McPerson",
+    "ReporterContactPhone": "+ 01 555 1234567"
+  },
+  "Disclosure": true,
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Harassed",
+    "Date": "2022-09-09T14:17:10Z",
+    "SourceUrl": "https://social.media/comment/87896745329",
+    "Ongoing": true,
+    "Harasser": "ForumUser123",
+    "HarassmentLocation": "website",
+    "HarassmentType": "doxing",
+    "HarassmentDescription": "Someone leaked my private home address with the intention of directing hate at me.",
+    "Samples": [
+      {
+        "ContentType": "image/png",
+        "Base64Encoded": true,
+        "Description": "Image of the comment leaking my address",
+        "Payload": "iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAMAAAAolt3jAAAAPFBMVEUZGyDBx8wyNTq5v8Sr\nsbYqLDFDRkvK0daEiY5IS1DDyc6vtbqiqK2LkZaIjpN1eX5cX2Q+QUYoKzAfISa2fY/BAAAA\nQElEQVQI12PAD5iYoQwBRiFkriCHMIKLUMzPyM3EwMDDxQjmsnMycPACGawQLpDkZIFwoXrZ\nSOUyMrIz8hFwMgCL5QFBsWv97gAAAABJRU5ErkJggg=="
+      }
+    ]
+  }
+}

--- a/samples/positive/development/harassment_sample_image.json
+++ b/samples/positive/development/harassment_sample_image.json
@@ -9,7 +9,7 @@
   "Disclosure": true,
   "Report": {
     "ReportClass": "Activity",
-    "ReportType": "Harassed",
+    "ReportType": "Harassment",
     "Date": "2022-09-09T14:17:10Z",
     "SourceUrl": "https://social.media/comment/87896745329",
     "Ongoing": true,

--- a/samples/positive/development/harassment_sample_irl.json
+++ b/samples/positive/development/harassment_sample_irl.json
@@ -1,0 +1,21 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterType": "Person",
+    "ReporterContactEmail": "contact@example.com",
+    "ReporterContactName": "Harassed McPerson",
+    "ReporterContactPhone": "+ 01 555 1234567"
+  },
+  "Disclosure": true,
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Harassed",
+    "Date": "2022-09-09T14:17:10Z",
+    "SourceUrl": "192.168.0.11",
+    "Ongoing": true,
+    "Harasser": "x.X.Fl4m3r.X.x",
+    "HarassmentLocation": "game",
+    "HarassmentType": "hate",
+    "HarassmentDescription": "The user called me a bunch of slurs."
+  }
+}

--- a/samples/positive/development/harassment_sample_url.json
+++ b/samples/positive/development/harassment_sample_url.json
@@ -9,7 +9,7 @@
   "Disclosure": true,
   "Report": {
     "ReportClass": "Activity",
-    "ReportType": "Harassed",
+    "ReportType": "Harassment",
     "Date": "2022-09-09T14:17:10Z",
     "SourceUrl": "http://irc.5ch.net",
     "Ongoing": true,

--- a/samples/positive/development/harassment_sample_url.json
+++ b/samples/positive/development/harassment_sample_url.json
@@ -1,0 +1,29 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterType": "Person",
+    "ReporterContactEmail": "contact@example.com",
+    "ReporterContactName": "Harassed McPerson",
+    "ReporterContactPhone": "+ 01 555 1234567"
+  },
+  "Disclosure": true,
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Harassed",
+    "Date": "2022-09-09T14:17:10Z",
+    "SourceUrl": "http://irc.5ch.net",
+    "Ongoing": true,
+    "Harasser": "@notarealperson",
+    "HarassmentDescription": "@notarealperson has published a deepfake of me doing something illegal, claiming that it was really me that did it.",
+    "HarassmentType": "defamation",
+    "HarassmentLocation": "chat",
+    "Samples": [
+      {
+        "ContentType": "image/x-uri",
+        "Base64Encoded": false,
+        "Description": "Url to an image ",
+        "Payload": "https://imagehostingservice.tld/image/123456789"
+      }
+    ]
+  }
+}

--- a/samples/positive/development/reporter_info_minimal.json
+++ b/samples/positive/development/reporter_info_minimal.json
@@ -3,7 +3,7 @@
   "ReporterInfo": {
     "ReporterOrg": "ExampleOrg",
     "ReporterOrgDomain": "example.com",
-    "ReporterOrgEmail": "reports@example.com",
+    "ReporterOrgEmail": "reports@example.com"
   },
   "Disclosure": true,
   "Report": {

--- a/samples/positive/development/reporter_info_minimal.json
+++ b/samples/positive/development/reporter_info_minimal.json
@@ -1,0 +1,16 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterOrg": "ExampleOrg",
+    "ReporterOrgDomain": "example.com",
+    "ReporterOrgEmail": "reports@example.com",
+  },
+  "Disclosure": true,
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Spam",
+    "Date": "2018-02-05T14:17:10Z",
+    "SourceIp": "192.0.2.55",
+    "SourcePort": 54321
+  }
+}

--- a/samples/positive/development/reporter_info_org.json
+++ b/samples/positive/development/reporter_info_org.json
@@ -1,0 +1,17 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterType": "Org",
+    "ReporterOrg": "ExampleOrg",
+    "ReporterOrgDomain": "example.com",
+    "ReporterOrgEmail": "reports@example.com",
+  },
+  "Disclosure": true,
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Spam",
+    "Date": "2018-02-05T14:17:10Z",
+    "SourceIp": "192.0.2.55",
+    "SourcePort": 54321
+  }
+}

--- a/samples/positive/development/reporter_info_org.json
+++ b/samples/positive/development/reporter_info_org.json
@@ -4,7 +4,7 @@
     "ReporterType": "Org",
     "ReporterOrg": "ExampleOrg",
     "ReporterOrgDomain": "example.com",
-    "ReporterOrgEmail": "reports@example.com",
+    "ReporterOrgEmail": "reports@example.com"
   },
   "Disclosure": true,
   "Report": {

--- a/samples/positive/development/reporter_info_person.json
+++ b/samples/positive/development/reporter_info_person.json
@@ -1,0 +1,15 @@
+{
+  "Version": "development",
+  "ReporterInfo": {
+    "ReporterType": "Person",
+    "ReporterOrg": "ExampleOrg"
+  },
+  "Disclosure": true,
+  "Report": {
+    "ReportClass": "Activity",
+    "ReportType": "Spam",
+    "Date": "2018-02-05T14:17:10Z",
+    "SourceIp": "192.0.2.55",
+    "SourcePort": 54321
+  }
+}

--- a/schemas/development/harassment.schema.json
+++ b/schemas/development/harassment.schema.json
@@ -5,7 +5,7 @@
   "description": "A format to report harassment.",
   "allOf": [
     {
-      "$ref": "xarf_shared.schema.json#/properties/XarfBasePersonal"
+      "$ref": "xarf_shared.schema.json#/properties/XarfBase"
     },
     {
       "type": "object",

--- a/schemas/development/harassment.schema.json
+++ b/schemas/development/harassment.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/xarf/schema-discussion/master/schemas/development/harassment.schema.json",
+  "title": "XARF HARASSMENT",
+  "description": "A format to report harassment.",
+  "allOf": [
+    {
+      "$ref": "xarf_shared.schema.json#/properties/XarfBasePersonal"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "Report": {
+          "allOf": [
+            {
+              "$ref": "xarf_shared.schema.json#/properties/IpAndUrlBasedReport"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "ReportClass": {
+                  "type": "string",
+                  "enum": ["Activity"]
+                },
+                "ReportType": {
+                  "type": "string",
+                  "enum": ["Harassment"]
+                }
+              }
+            },
+            {
+              "$ref": "xarf_shared.schema.json#/properties/Harassment"
+            },
+            {
+              "$ref": "xarf_shared.schema.json#/properties/CommonProps"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/schemas/development/xarf.schema.json
+++ b/schemas/development/xarf.schema.json
@@ -39,6 +39,9 @@
     },
     {
       "$ref": "openservice.schema.json"
+    },
+    {
+      "$ref": "harassment.schema.json"
     }
   ]
 }

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -33,6 +33,7 @@
       "required": ["ReporterInfo"]
     },
     "XarfCommon": {
+      "type": "object",
       "properties": {
         "Disclosure": {
           "type": "boolean",
@@ -203,16 +204,10 @@
     },
     "XarfBasePersonal": {
       "type": "object",
+      "$comment": "Front for XarfCommon, for extensions in the future",
       "allOf": [
         {
           "$ref": "#/$defs/XarfCommon"
-        },
-        {
-          "properties": {
-            "": {
-
-            }
-          }
         }
       ]
     },
@@ -567,7 +562,15 @@
         "HarassmentType": {
           "oneOf": [
             {
-              "enum": ["doxing", "stalking", "sexual", "believes", "defamation", "extorsion", "hate"]
+              "enum": [
+                "doxing",
+                "stalking",
+                "sexual",
+                "believes",
+                "defamation",
+                "extorsion",
+                "hate"
+              ]
             },
             {
               "type": "string",

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -565,7 +565,7 @@
             "sexual",
             "believes",
             "defamation",
-            "extorsion",
+            "extortion",
             "hate"
           ]
         },

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -2,10 +2,58 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/xarf/schema-discussion/master/schemas/development/xarf_shared.schema.json",
   "type": "object",
+  "$defs": {
+    "Date": {
+      "description": "stores either a single date or two dates, one for the first occurrence of the event, one for the most recent",
+      "type": "object",
+      "required": ["Date"],
   "properties": {
+        "Date": {
+          "format": "date-time",
+          "type": "string",
+          "description": "most recent date-time the event was noticed"
+        },
+        "FirstSeen": {
+          "format": "date-time",
+          "type": "string",
+          "description": "date-time the event was first noticed. Can be omitted if it is the same as Date"
+        }
+      }
+    },
+    "XarfInstitutional": {
+      "type": "object",
+      "properties": {
+        "ReporterInfo": {
+          "$ref": "#/$defs/ReporterInfo"
+        },
+        "OnBehalfOf": {
+          "$ref": "#/$defs/OnBehalfOf"
+        }
+      },
+      "required": ["ReporterInfo"]
+    },
+    "XarfCommon": {
+      "properties": {
+        "Disclosure": {
+          "type": "boolean",
+          "description": "if this event is disclosed or not",
+          "default": true
+        },
+        "Version": {
+          "const": "development"
+        },
+        "InternalProcessing": {
+          "$ref": "#/$defs/InternalProcessing"
+        }
+      },
+      "required": ["Disclosure", "Version"]
+    },
     "ReporterInfo": {
       "type": "object",
       "properties": {
+        "ReporterType": {
+          "enum": ["Org", "Person"]
+        },
         "ReporterOrg": {
           "type": "string",
           "description": "name of the reporter organisation",
@@ -41,7 +89,16 @@
           "minLength": 3
         }
       },
+      "if": {
+        "not": {
+          "properties": {
+            "ReporterType": "Person"
+          }
+        },
+        "then": {
       "required": ["ReporterOrg", "ReporterOrgDomain", "ReporterOrgEmail"]
+        }
+      }
     },
     "OnBehalfOf": {
       "type": "object",
@@ -83,29 +140,81 @@
         "ComplainantOrgEmail"
       ]
     },
+    "InternalProcessing": {
+      "type": "object",
+      "description": "Information about the reportee for internal processing. This should be ignored if the reporter isn't authorized. It's intended to be used for relaying internaly generated xarf-reports to automation software.",
+      "properties": {
+        "SubscriberInformation": {
+          "type": "object",
+          "description": "Information about the reportee/customer.",
+          "properties": {
+            "ID": {
+              "type": "string",
+              "description": "Internal ID of the reportee."
+        },
+            "SubscriberData": {
+              "type": "object",
+              "description": "Data about a customer normaly returned by a resolver in the process of determining the reportee.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "ContractInformation": {
+          "type": "object",
+          "description": "Information about the reportee's/customer's contract.",
+          "properties": {
+            "ID": {
+              "type": "string",
+              "description": "Internal ID of the reportee's contract."
+        },
+            "ResolverData": {
+              "type": "object",
+              "description": "Data about a customers contract normaly returned by a resolver in the process of determining the reportee.",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "EventTags": {
+          "type": "array",
+          "description": "Custom tags for classification, metrics and other internal uses.",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+        }
+      },
+  "properties": {
     "XarfBase": {
       "description": "Base properties for all xarf reports",
       "type": "object",
-      "properties": {
-        "ReporterInfo": {
-          "$ref": "#/properties/ReporterInfo"
+      "allOf": [
+        {
+          "$ref": "#/$defs/XarfInstitutional"
         },
-        "OnBehalfOf": {
-          "$ref": "#/properties/OnBehalfOf"
-        },
-        "Disclosure": {
-          "type": "boolean",
-          "description": "if this event is disclosed or not",
-          "default": true
-        },
-        "Version": {
-          "const": "development"
-        },
-        "InternalProcessing": {
-          "$ref": "#/properties/InternalProcessing"
+        {
+          "$ref": "#/$defs/XarfCommon"
         }
-      },
-      "required": ["ReporterInfo", "Disclosure", "Version"]
+      ]
+    },
+    "XarfBasePersonal": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/$defs/XarfCommon"
+        },
+        {
+          "properties": {
+            "": {
+
+            }
+          }
+        }
+      ]
     },
     "ReportBase": {
       "description": "Base properties for the report part of all xarf report types",
@@ -161,7 +270,7 @@
           "$ref": "#/properties/ReportBase"
         },
         {
-          "$ref": "#/properties/Date"
+          "$ref": "#/$defs/Date"
         },
         {
           "type": "object",
@@ -202,7 +311,7 @@
           "$ref": "#/properties/ReportBase"
         },
         {
-          "$ref": "#/properties/Date"
+          "$ref": "#/$defs/Date"
         },
         {
           "type": "object",
@@ -307,23 +416,6 @@
             "$ref": "#/properties/Sample"
           },
           "minItems": 1
-        }
-      }
-    },
-    "Date": {
-      "description": "stores either a single date or two dates, one for the first occurrence of the event, one for the most recent",
-      "type": "object",
-      "required": ["Date"],
-      "properties": {
-        "Date": {
-          "format": "date-time",
-          "type": "string",
-          "description": "most recent date-time the event was noticed"
-        },
-        "FirstSeen": {
-          "format": "date-time",
-          "type": "string",
-          "description": "date-time the event was first noticed. Can be omitted if it is the same as Date"
         }
       }
     },

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -51,6 +51,7 @@
     },
     "ReporterInfo": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "ReporterType": {
           "$comment": "Contact info is optional if the reporter is a natural person",

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -53,6 +53,7 @@
       "type": "object",
       "properties": {
         "ReporterType": {
+          "$comment": "Contact info is optional if the reporter is a natural person",
           "enum": ["Org", "Person"]
         },
         "ReporterOrg": {
@@ -91,11 +92,7 @@
         }
       },
       "if": {
-        "not": {
-          "properties": {
-            "ReporterType": "Person"
-          }
-        }
+        "not": { "properties": { "ReporterType": { "const": "Person" } } }
       },
       "then": {
         "required": ["ReporterOrg", "ReporterOrgDomain", "ReporterOrgEmail"]
@@ -104,6 +101,10 @@
     "OnBehalfOf": {
       "type": "object",
       "properties": {
+        "ComplainantType": {
+          "$comment": "Contact info is optional if the reporter is a natural person",
+          "enum": ["Org", "Person"]
+        },
         "ComplainantOrg": {
           "type": "string",
           "description": "name of the complainant organisation",
@@ -135,11 +136,18 @@
           "minLength": 3
         }
       },
-      "required": [
-        "ComplainantOrg",
-        "ComplainantOrgDomain",
-        "ComplainantOrgEmail"
-      ]
+      "if": {
+        "not": {
+          "properties": { "ComplainantType": { "const": "Person" } }
+        }
+      },
+      "then": {
+        "required": [
+          "ComplainantOrg",
+          "ComplainantOrgDomain",
+          "ComplainantOrgEmail"
+        ]
+      }
     },
     "InternalProcessing": {
       "type": "object",
@@ -197,15 +205,6 @@
         {
           "$ref": "#/$defs/XarfInstitutional"
         },
-        {
-          "$ref": "#/$defs/XarfCommon"
-        }
-      ]
-    },
-    "XarfBasePersonal": {
-      "type": "object",
-      "$comment": "Front for XarfCommon, for extensions in the future",
-      "allOf": [
         {
           "$ref": "#/$defs/XarfCommon"
         }
@@ -291,7 +290,7 @@
             },
             "ASN": {
               "type": "integer",
-              "description": "autonomous system number the reportet ip belongs to",
+              "description": "autonomous system number the reported ip belongs to",
               "minimum": 1,
               "maximum": 4199999999
             }
@@ -340,7 +339,7 @@
                 },
                 "ASN": {
                   "type": "integer",
-                  "description": "autonomous system number the reportet ip belongs to",
+                  "description": "autonomous system number the reported ip belongs to",
                   "minimum": 1,
                   "maximum": 4199999999
                 }
@@ -560,22 +559,14 @@
           "description": "Description/Reason why the reported behavior classifies as harassment."
         },
         "HarassmentType": {
-          "oneOf": [
-            {
-              "enum": [
-                "doxing",
-                "stalking",
-                "sexual",
-                "believes",
-                "defamation",
-                "extorsion",
-                "hate"
-              ]
-            },
-            {
-              "type": "string",
-              "$comment": "Encourage the use of existing types, user input is hard to classify"
-            }
+          "enum": [
+            "doxing",
+            "stalking",
+            "sexual",
+            "believes",
+            "defamation",
+            "extorsion",
+            "hate"
           ]
         },
         "HarassmentLocation": {

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -95,10 +95,10 @@
           "properties": {
             "ReporterType": "Person"
           }
-        },
-        "then": {
-          "required": ["ReporterOrg", "ReporterOrgDomain", "ReporterOrgEmail"]
         }
+      },
+      "then": {
+        "required": ["ReporterOrg", "ReporterOrgDomain", "ReporterOrgEmail"]
       }
     },
     "OnBehalfOf": {

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -7,7 +7,7 @@
       "description": "stores either a single date or two dates, one for the first occurrence of the event, one for the most recent",
       "type": "object",
       "required": ["Date"],
-  "properties": {
+      "properties": {
         "Date": {
           "format": "date-time",
           "type": "string",
@@ -96,7 +96,7 @@
           }
         },
         "then": {
-      "required": ["ReporterOrg", "ReporterOrgDomain", "ReporterOrgEmail"]
+          "required": ["ReporterOrg", "ReporterOrgDomain", "ReporterOrgEmail"]
         }
       }
     },
@@ -151,7 +151,7 @@
             "ID": {
               "type": "string",
               "description": "Internal ID of the reportee."
-        },
+            },
             "SubscriberData": {
               "type": "object",
               "description": "Data about a customer normaly returned by a resolver in the process of determining the reportee.",
@@ -168,7 +168,7 @@
             "ID": {
               "type": "string",
               "description": "Internal ID of the reportee's contract."
-        },
+            },
             "ResolverData": {
               "type": "object",
               "description": "Data about a customers contract normaly returned by a resolver in the process of determining the reportee.",
@@ -186,8 +186,8 @@
           }
         }
       }
-        }
-      },
+    }
+  },
   "properties": {
     "XarfBase": {
       "description": "Base properties for all xarf reports",
@@ -552,50 +552,31 @@
         }
       }
     },
-    "InternalProcessing": {
+    "Harassment": {
       "type": "object",
-      "description": "Information about the reportee for internal processing. This should be ignored if the reporter isn't authorized. It's intended to be used for relaying internaly generated xarf-reports to automation software.",
+      "description": "Details of someone harassing someone else.",
       "properties": {
-        "SubscriberInformation": {
-          "type": "object",
-          "description": "Information about the reportee/customer.",
-          "properties": {
-            "ID": {
-              "type": "string",
-              "description": "Internal ID of the reportee."
-            },
-            "SubscriberData": {
-              "type": "object",
-              "description": "Data about a customer normaly returned by a resolver in the process of determining the reportee.",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          }
+        "Harasser": {
+          "type": "string",
+          "description": "Specify the identity of the harassing individual, eg. name, username, phone number or email"
         },
-        "ContractInformation": {
-          "type": "object",
-          "description": "Information about the reportee's/customer's contract.",
-          "properties": {
-            "ID": {
-              "type": "string",
-              "description": "Internal ID of the reportee's contract."
-            },
-            "ResolverData": {
-              "type": "object",
-              "description": "Data about a customers contract normaly returned by a resolver in the process of determining the reportee.",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          }
+        "HarassmentDescription": {
+          "type": "string",
+          "description": "Description/Reason why the reported behavior classifies as harassment."
         },
-        "EventTags": {
-          "type": "array",
-          "description": "Custom tags for classification, metrics and other internal uses.",
-          "items": {
-            "type": "string"
-          }
+        "HarassmentType": {
+          "oneOf": [
+            {
+              "enum": ["doxing", "stalking", "sexual", "believes", "defamation", "extorsion", "hate"]
+            },
+            {
+              "type": "string",
+              "$comment": "Encourage the use of existing types, user input is hard to classify"
+            }
+          ]
+        },
+        "HarassmentLocation": {
+          "enum": ["website", "chat", "game"]
         }
       }
     }

--- a/schemas/development/xarf_shared.schema.json
+++ b/schemas/development/xarf_shared.schema.json
@@ -578,7 +578,8 @@
         "HarassmentLocation": {
           "enum": ["website", "chat", "game"]
         }
-      }
+      },
+      "required": ["Harasser", "HarassmentDescription"]
     }
   }
 }


### PR DESCRIPTION
# Proposal: new "Harassment" report type

As requested, this is the first draft of a new "Harassment" type. Closes #34

The type itself will report an _harasser_ and has a description, the type of harassment and a location attribute. 
Either an ip or an url has to be supplied. I know that's not always possible, eg. with the `HarassmentLocation: game` property. That's also the reason I didn't include any "irl" type locations, eg. "workplace". 

**We could totally remove the "game" location**, but I think there's still a case for it: It could be used as a backend for a "report this user" button in a game. So maybe it's not useless.

Other than that, **I'm not sure on the `HarassmentType`** properties I've chosen. Something like comments on skin color, nationality, ableism and misandry would all be classified as "hate", but I'm not sure whether a more precise classification is necessary. 

There's also a conceptual difference from previous report types:  The report is most likely created by a natural person, so `ReporterOrg` doesn't apply. I've therefore made adding personal information as a reporter optional and am **allowing private actors to create a report without `ReporterOrg*` properties being set.** 


## I want feedback on:

- Are you content with `HarassmentType`?
- Should we include `game` as a location?
- Should we add a location?